### PR TITLE
[Feat] 유저 프로필 피드 모아보기 및 게시물 수 카운트 구현

### DIFF
--- a/src/main/java/com/example/petlog/controller/FeedController.java
+++ b/src/main/java/com/example/petlog/controller/FeedController.java
@@ -77,4 +77,17 @@ public class FeedController {
         feedService.deleteFeed(feedId, userId);
         return ResponseEntity.noContent().build();
     }
+
+    // 특정 유저의 피드 모아보기 (마이페이지/상대방 프로필)
+    @GetMapping("/user/{targetUserId}/viewer/{viewerId}")
+    @Operation(summary = "유저별 피드 조회 (마이페이지)", description = "특정 유저(targetUserId)가 작성한 피드 목록을 조회합니다.")
+    public ResponseEntity<List<FeedResponse.GetFeedDto>> getUserFeeds(
+            @Parameter(description = "프로필 주인 ID", required = true)
+            @PathVariable Long targetUserId,
+
+            @Parameter(description = "보고 있는 사람 ID (좋아요 여부 확인용)", required = true)
+            @PathVariable Long viewerId
+    ) {
+        return ResponseEntity.ok(feedService.getUserFeeds(targetUserId, viewerId));
+    }
 }

--- a/src/main/java/com/example/petlog/repository/FeedRepository.java
+++ b/src/main/java/com/example/petlog/repository/FeedRepository.java
@@ -10,4 +10,10 @@ import java.util.List;
 public interface FeedRepository extends JpaRepository<Feed, Long> {
     // 생성일 기준 내림차순(최신순)으로 모든 피드를 조회합니다.
     List<Feed> findAllByOrderByCreatedAtDesc();
+
+    //특정유저의 피드만 최신순으로 조회
+    List<Feed> findAllByUserIdOrderByCreatedAtDesc(Long userId);
+
+    //특정유저의 게시글 수 조회
+    Long countByUserId(Long userId);
 }

--- a/src/main/java/com/example/petlog/service/FeedService.java
+++ b/src/main/java/com/example/petlog/service/FeedService.java
@@ -21,4 +21,7 @@ public interface FeedService {
 
     // 피드 삭제
     void deleteFeed(Long feedId, Long userId);
+
+    // 특정유저의 피드목록 조회
+    List<FeedResponse.GetFeedDto> getUserFeeds(Long targetUserId, Long viewerId);
 }

--- a/src/main/java/com/example/petlog/service/impl/FeedServiceImpl.java
+++ b/src/main/java/com/example/petlog/service/impl/FeedServiceImpl.java
@@ -147,4 +147,15 @@ public class FeedServiceImpl implements FeedService {
         // DTO 생성 (파라미터 6개)
         return FeedResponse.GetFeedDto.of(feed, nickname, petName, fullImageUrl, likeCount, isLiked, commentCount, recentComments);
     }
+
+    @Override
+    public List<FeedResponse.GetFeedDto> getUserFeeds(Long targetUserId, Long viewerId) {
+        // 1. 해당 유저가 쓴 글만 DB에서 가져옴
+        List<Feed> userFeeds = feedRepository.findAllByUserIdOrderByCreatedAtDesc(targetUserId);
+
+        // 2. DTO로 변환 (viewerId를 넘겨서 내가 좋아요 눌렀는지도 확인 가능하게 함)
+        return userFeeds.stream()
+                .map(feed -> convertToDto(feed, viewerId))
+                .collect(Collectors.toList());
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- Closes #9  

## 작업 내용
### 1. 유저별 피드 조회 기능 (마이페이지)
- **API 구현:** `GET /api/feeds/user/{targetUserId}/viewer/{viewerId}` 엔드포인트를 추가하여 특정 유저의 피드 목록을 조회할 수 있도록 했습니다.
- **데이터 접근:** `FeedRepository`에 `findAllByUserId...` 메서드를 추가하여 특정 사용자의 글만 필터링하여 가져옵니다.
- **상호작용 반영:** 조회 시 `viewerId`(보는 사람)를 함께 전달받아, 타인의 프로필을 볼 때도 내가 그 글에 좋아요를 눌렀는지(`isLiked`) 상태를 정확히 확인할 수 있습니다.

### 2. 게시물 통계 지원
- **카운트 쿼리:** 프로필 상단 "게시물 N개" 표시를 지원하기 위해 `countByUserId` 메서드를 Repository에 추가했습니다. (추후 User 프로필 API와 조합하여 사용 예정)

## 변경된 API 명세
| 기능 | Method | URL | 설명 |
| :--- | :--- | :--- | :--- |
| **유저 피드 모아보기** | GET | `/api/feeds/user/{targetId}/viewer/{viewerId}` | targetId 유저가 쓴 글 목록 조회 (viewerId 시점) |

## 테스트 결과
- [x] Postman 테스트 완료:
    - `user/1/viewer/1` 호출 시 1번 유저가 쓴 글만 필터링 되어 반환됨을 확인
    - 다른 유저의 ID로 조회 시 해당 유저의 글이 반환됨을 확인

- [x] 좋아요 및 댓글 기능 확인 :
    - 좋아요가 상세조회할때 잘 나오는지 테스트 완료.
    - 좋아요 목록에 누른사람이 뜨는지 확인 완료.
    - 특정유저 피드 조회 테스트까지 완료.

## 📸 스크린샷 (선택)
#### 1번유저의 피드를 조회
<img width="876" height="827" alt="image" src="https://github.com/user-attachments/assets/3c8253b1-82ea-45ff-a76b-4940e5bca06a" />

#### 2번 유저의 피드 조회 한 경우
<img width="868" height="520" alt="image" src="https://github.com/user-attachments/assets/c864a99c-fcb4-4186-a17f-64dc2e6cb61d" />


## 💬 리뷰 요구사항
- 현재는 전체 목록을 한 번에 가져오지만, 추후 피드 개수가 많아질 것을 대비해 페이징(Paging) 처리가 필요할 수 있습니다. (Feat#5 예정)